### PR TITLE
Fixes the entity callback (destroy) leak

### DIFF
--- a/tween.js
+++ b/tween.js
@@ -396,6 +396,8 @@ pc.extend(pc, function () {
                 var repeat = this._repeat(_extra);
                 if (!repeat) {
                     this.fire("complete", _extra);
+                    if (this.entity)
+                        this.entity.off('destroy', this.stop, this);
                     if (this._chained) this._chained.start();
                 } else {
                     this.fire("loop");
@@ -676,9 +678,7 @@ pc.extend(pc, function () {
         var tween = this._app.tween(target);
         tween.entity = this;
 
-        this.on('destroy', function () {
-            tween.stop();
-        });
+        this.once('destroy', tween.stop, tween);
 
         if (options && options.element) {
             // specifiy a element property to be updated


### PR DESCRIPTION
Removes 'destroy' callback from entity when sequence is completed and does not repeat.
Prevents from staking callbacks (and leaking tween objects) for long-living objects.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
