### PR TITLE
Quaternion as a target tween

### DIFF
--- a/tween.js
+++ b/tween.js
@@ -232,12 +232,17 @@ pc.extend(pc, function () {
                 }
 
                 if (this._slerp) {
-                    this._fromQuat.setFromEulerAngles(this.target.x, this.target.y, this.target.z);
-
                     _x = this._properties.x !== undefined ? this._properties.x : this.target.x;
                     _y = this._properties.y !== undefined ? this._properties.y : this.target.y;
                     _z = this._properties.z !== undefined ? this._properties.z : this.target.z;
-                    this._toQuat.setFromEulerAngles(_x, _y, _z);
+                    
+                    if (this._properties.w !== undefined) {
+                        this._fromQuat.copy(this.target);
+                        this._toQuat.set(_x, _y, _z, this._properties.w);
+                    } else {
+                        this._fromQuat.setFromEulerAngles(this.target.x, this.target.y, this.target.z);
+                        this._toQuat.setFromEulerAngles(_x, _y, _z);
+                    }
                 }
             }
 


### PR DESCRIPTION
Allow to provide Quaternion as a target tween. 

This PR allows to provide a target rotation in both Quaternions and Euler Angles:

```js
var targetRotation = someEntity.getLocalRotation();
    
entity.tween(entity.getLocalRotation())
    .rotate(targetRotation, 2, pc.QuadraticInOut)
    .start();
```

Fixes #

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
