### PR TITLE
Can re-use same tweens

### DIFF
--- a/tween.js
+++ b/tween.js
@@ -31,7 +31,10 @@ pc.extend(pc, function () {
 
             // add any tweens that were added mid-update
             if (this._add.length) {
-                this._tweens = this._tweens.concat(this._add);
+                for (let i = 0; i < this._add.length; i++) {
+                    if (this._tweens.indexOf(this._add[i]) > -1) continue;
+                    this._tweens.push(this._add[i]);
+                }
                 this._add.length = 0;
             }
         }


### PR DESCRIPTION
Hello.

I would like to propose this simple change to have the ability of pooling tweens.

In my project I wanted to evade constantly creating tween objects, so I stick with re-using all the repeating tweens. It turned out, that there was a bug in TweenManager, that allowed adding the same tween more then one time to the current _tweens array, which caused tween speedup by a factor of how many times same tween instance was added.

I've thrown together demo project so you can see the problem https://playcanvas.com/project/926296/overview/pooltweenexample

Here's how it looks

https://user-images.githubusercontent.com/1550079/167999454-f102d20f-af2b-4256-bd39-affc0ca847e5.mp4


I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
