### PR TITLE
onUpdate, onComplete, onLoop methods instead of events

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ E.g.
 var color = new pc.Color(1, 0, 0);
 
 var tween = app.tween(color).to(new pc.Color(0, 1, 1), 1, pc.Linear);
-tween.on('update', function (dt) {
+tween.onUpdate(function (dt) {
     material.diffuse = color;
     material.update();
 });
@@ -133,7 +133,7 @@ E.g.
 entity
 .tween(entity.getLocalPosition())
 .to({x: 10, y: 0, z: 0}, 1, pc.Linear)
-.on('complete', function () {
+.onComplete(function () {
    console.log('tween completed');
 });
 ```
@@ -149,7 +149,7 @@ entity
 .tween(entity.getLocalPosition())
 .to({x: 10, y: 0, z: 0}, 1, pc.Linear)
 .loop(true)
-.on('loop', function () {
+.onLoop(function () {
    console.log('tween loop');
 });
 ```

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ E.g.
 var color = new pc.Color(1, 0, 0);
 
 var tween = app.tween(color).to(new pc.Color(0, 1, 1), 1, pc.Linear);
-tween.onUpdate(function (dt) {
+tween.onUpdate((dt) => {
     material.diffuse = color;
     material.update();
 });
@@ -136,7 +136,7 @@ E.g.
 entity
 .tween(entity.getLocalPosition())
 .to({x: 10, y: 0, z: 0}, 1, pc.Linear)
-.onComplete(function () {
+.onComplete(() => {
    console.log('tween completed');
 });
 ```
@@ -152,7 +152,7 @@ entity
 .tween(entity.getLocalPosition())
 .to({x: 10, y: 0, z: 0}, 1, pc.Linear)
 .loop(true)
-.onLoop(function () {
+.onLoop(() => {
    console.log('tween loop');
 });
 ```

--- a/README.md
+++ b/README.md
@@ -107,9 +107,12 @@ To reverse a tween call `tween.reverse()`.
 
 # Events
 
-## `update(dt)`
+To subscribe to events during Tween execution, use a these methods:
 
-This is fired on every update cycle. You can use this method to manually update something in your code using the tweened value.
+## `onUpdate`
+
+This is called on every update cycle. You can use this method to manually update something in your code using the tweened value.
+It provides `dt` argument.
 
 E.g.
 
@@ -123,9 +126,9 @@ tween.onUpdate(function (dt) {
 });
 ```
 
-## `complete()`
+## `onComplete`
 
-This is fired when the tween is finished. If the tween is looping the `loop` event is fired instead.
+This is called when the tween is finished. If the tween is looping the `onLoop` will be called instead.
 
 E.g.
 
@@ -138,9 +141,9 @@ entity
 });
 ```
 
-## `loop()`
+## `onLoop`
 
-This is fired whenever a looping tween finishes a cycle. This is fired instead of the `complete` event for looping tweens.
+This is called whenever a looping tween finishes a cycle. This is called instead of the `onComplete` for looping tweens.
 
 E.g.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playcanvas-tween",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "author": "PlayCanvas <support@playcanvas.com>",
   "homepage": "https://playcanvas.com",
   "description": "Tween library for PlayCanvas engine",
@@ -32,6 +32,6 @@
   },
   "scripts": {
     "lint": "eslint --ext .js tween.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "start test/index.html"
   }
 }

--- a/test/tween-test.js
+++ b/test/tween-test.js
@@ -19,7 +19,7 @@ QUnit.test("Tween Vec4 to Vec4", function (assert) {
 
     var tween = new pc.Tween(value, app._tweenManager);
     tween.to(target, 0.1, pc.SineOut)
-        .on('complete', function () {
+        .onComplete(function () {
             assert.equal(value.x, 10);
             assert.equal(value.y, 10);
             assert.equal(value.z, 10);
@@ -40,7 +40,7 @@ QUnit.test("Tween Vec3 to Vec3", function (assert) {
 
     var tween = new pc.Tween(value, app._tweenManager);
     tween.to(target, 0.1, pc.SineOut)
-        .on('complete', function () {
+        .onComplete(function () {
             assert.equal(value.x, 10);
             assert.equal(value.y, 10);
             assert.equal(value.z, 10);
@@ -60,7 +60,7 @@ QUnit.test("Tween Vec2 to Vec2", function (assert) {
 
     var tween = new pc.Tween(value, app._tweenManager);
     tween.to(target, 0.1, pc.SineOut)
-        .on('complete', function () {
+        .onComplete(function () {
             assert.equal(value.x, 10);
             assert.equal(value.y, 10);
             done();
@@ -76,7 +76,7 @@ QUnit.test("entity tween getLocalPosition.x", function (assert) {
 
     var e = new pc.Entity();
     app.root.addChild(e);
-    e.tween(e.getLocalPosition()).to({ x: 10 }, 0.1, pc.SineOut).start().on('complete', function () {
+    e.tween(e.getLocalPosition()).to({ x: 10 }, 0.1, pc.SineOut).start().onComplete(function () {
         assert.equal(e.getLocalPosition().x, 10);
         e.destroy();
         done();
@@ -89,7 +89,7 @@ QUnit.test("entity tween localPosition.x", function (assert) {
     var e = new pc.Entity();
     app.root.addChild(e);
 
-    e.tween(e.localPosition).to({ x: 10 }, 0.1, pc.SineOut).start().on('complete', function () {
+    e.tween(e.localPosition).to({ x: 10 }, 0.1, pc.SineOut).start().onComplete(function () {
         assert.equal(e.getLocalPosition().x, 10);
         e.destroy();
         done();
@@ -104,7 +104,7 @@ QUnit.test("entity tween getLocalPosition to Vec3", function (assert) {
 
     var target = new pc.Vec3(10, 10, 10);
 
-    e.tween(e.getLocalPosition()).to(target, 0.1, pc.SineOut).start().on('complete', function () {
+    e.tween(e.getLocalPosition()).to(target, 0.1, pc.SineOut).start().onComplete(function () {
         assert.equal(e.getLocalPosition().x, 10);
         assert.equal(e.getLocalPosition().y, 10);
         assert.equal(e.getLocalPosition().z, 10);
@@ -125,7 +125,7 @@ QUnit.test("entity tween element color", function (assert) {
 
     var target = new pc.Color(0.5, 0.5, 0.5, 0.5);
 
-    e.tween(e.element.color, { element: 'color' }).to(target, 0.1, pc.SineOut).start().on('complete', function () {
+    e.tween(e.element.color, { element: 'color' }).to(target, 0.1, pc.SineOut).start().onComplete(function () {
         assert.equal(e.element.color.r, 0.5);
         assert.equal(e.element.color.g, 0.5);
         assert.equal(e.element.color.b, 0.5);
@@ -147,7 +147,7 @@ QUnit.test("entity tween.rotate getLocalEulerAngles", function (assert) {
 
     var target = new pc.Vec3(0, 0, 180);
 
-    e.tween(e.getLocalEulerAngles()).rotate(target, 0.1, pc.SineOut).start().on('complete', function () {
+    e.tween(e.getLocalEulerAngles()).rotate(target, 0.1, pc.SineOut).start().onComplete(function () {
         assert.equal(e.getLocalEulerAngles().x, target.x);
         assert.equal(e.getLocalEulerAngles().y, target.y);
         assert.equal(e.getLocalEulerAngles().z, target.z);

--- a/tween.js
+++ b/tween.js
@@ -326,6 +326,21 @@ pc.extend(pc, function () {
             return this;
         },
 
+        onUpdate: function (callback) {
+            this.on('update', callback);
+            return this;
+        },
+
+        onComplete: function (callback) {
+            this.on('complete', callback);
+            return this;
+        },
+
+        onLoop: function (callback) {
+            this.on('loop', callback);
+            return this;
+        },
+
         update: function (dt) {
             if (this.stopped) return false;
 


### PR DESCRIPTION
Based on recent PR (https://github.com/playcanvas/engine/pull/5481) to the engine, it has a breaking change where `EventEmitter.on` does not return "self" for chaining, but returns `EventHandle`.
This breaks the ways were recommended by this library.

**Unfortunately, after the 1.66 engine update, migration by users of this library will be required.**
To avoid it, this PR introduces three new methods: `onUpdate`, `onComplete`, `onLoop` to be used instead of events notation.

So this code:

```js
entity
.tween(entity.getLocalPosition())
.to({x: 10, y: 0, z: 0}, 1, pc.Linear)
.on('complete', function () {
   console.log('tween completed');
})
.start();
```

Now should be:

```js
entity
.tween(entity.getLocalPosition())
.to({x: 10, y: 0, z: 0}, 1, pc.Linear)
.onComplete(() => {
   console.log('tween completed');
})
.start();
```

The same applies to `update` and `loop` events.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
