### PR TITLE
[typescript] adding missing types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -136,11 +136,11 @@ declare namespace pc {
         
         update: (dt: number) => boolean;
         
-        on: (
-            name: string,
-            callback: callbacks.HandleEvent,
-            scope?: unknown
-        ) => this;
+        onUpdate: (callback: () => void) => Tween;
+
+        onComplete: (callback: () => void) => Tween;
+
+        onLoop: (callback: () => void) => Tween;
     }
     
     export interface TweenOptions {


### PR DESCRIPTION
The most recent change in the tween library adding some new event functions onUpdate, onComplete, etc. However they are missing the types. This PR adds the missing functions for the Tween class.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
